### PR TITLE
Added KU Leuven and USC

### DIFF
--- a/university-policies.md
+++ b/university-policies.md
@@ -65,3 +65,7 @@ University of Massachusetts | [Source](umass.edu/coronavirus/)
 Graduate Institute Geneva | [Source](https://graduateinstitute.ch/novel-coronavirus2019)
 
 Freie Universität Berlin | [Source](https://www.fu-berlin.de/en/sites/coronavirus/index.html)
+
+KU Leuven | [Source](https://www.kuleuven.be/coronavirus/english/Coronavirus-ENG)
+
+USC | [Source](https://sites.usc.edu/coronavirus/)


### PR DESCRIPTION
KU Leuven: "These guidelines are effective up to and including 3 April. [...] Classes will only be taught online. All other forms of teaching are suspended, regardless of the course type or size of the group."

USC: "USC is now extending our period of remote instruction until Tuesday, April 14."